### PR TITLE
Fix the object destroyed

### DIFF
--- a/src/main/madara-app.ts
+++ b/src/main/madara-app.ts
@@ -303,7 +303,9 @@ async function attachAndSendLogs(
           containerName,
           logs: buffer.toString(),
         };
-        window.webContents.send('app-logs', event);
+        if (!window.isDestroyed()) {
+          window.webContents.send('app-logs', event);
+        }
       });
     }
   );

--- a/src/main/madara.ts
+++ b/src/main/madara.ts
@@ -192,7 +192,9 @@ export async function start(window: BrowserWindow, config: MadaraConfig) {
 
   // BY DEFAULT SUBSTRATE LOGS TO STDERR SO WE USE THIS
   childProcess.stderr.on('data', (data) => {
-    window.webContents.send('node-logs', data.toString());
+    if (!window.isDestroyed()) {
+      window.webContents.send('node-logs', data.toString());
+    }
   });
 
   // Update the react state when the node is stopped

--- a/src/renderer/pages/Apps.tsx
+++ b/src/renderer/pages/Apps.tsx
@@ -16,6 +16,7 @@ import Button from 'renderer/components/Button';
 import Tooltip from 'renderer/components/Tooltip';
 import defaultToastStyleOptions from 'shared/constants';
 import {
+  fetchAndSetRunningApps,
   selectInstalledApps,
   selectRunningApps,
   setAppAsInstalled,
@@ -174,6 +175,7 @@ export default function Apps() {
   };
 
   useEffect(() => {
+    dispatch(fetchAndSetRunningApps());
     dispatch(setupInstalledApps());
 
     window.electron.ipcRenderer.madaraApp.onAppDownloadProgress(


### PR DESCRIPTION
related to issue #40 

the fixed is just adding a simple check on the browser window of each of the logs that cause an error since the logs is send into the browser window at all time and with sudden close it would encounter an error and to fix it is that once the browser window is no longer open then it would stop sending the logs.